### PR TITLE
Fix IPv6 compatibility

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -47,7 +47,7 @@ class metricHandler:
             resp.body = msg
 
         try:
-            socket.gethostbyname(self._target)
+            socket.getaddrinfo(self._target, None)
         except socket.gaierror as e:
             msg = f'Target does not exist in DNS: {e}'
             logging.error(msg)


### PR DESCRIPTION
Replace gethostbyname() by getaddrinfo() to provide IPv6 compatibility, since gethostbyname() support only IPv4.