### PR TITLE
added py_module parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,5 @@ setup(
     author='Stefan Safar',
     author_email='stefan.safar@showmax.com',
     scripts=['main.py', 'handler.py', 'collector.py'],
+    py_modules=[],
 )


### PR DESCRIPTION
new setup tools seem to require this, otherwise builds will fail

Signed-off-by: Tim Beermann <beermann@osism.tech>
