### PR TITLE
Get bgp summaries for all VRFs configured on the switch

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -318,7 +318,7 @@ class AristaMetricsCollector(object):
             yield sfp_alarms
 
     def collect_bgp(self):
-        data = self.switch_command("show ip bgp summary")
+        data = self.switch_command("show ip bgp summary vrf all")
         ipv4 = data["result"][0]["vrfs"]
         data = self.switch_command("show ipv6 bgp summary")
         ipv6 = data["result"][0]["vrfs"]


### PR DESCRIPTION
The command The `show ip bgp summary` command will only capture information for the default vrf. Adding `vrf all` will extend this to all configure VRFs.